### PR TITLE
Allows to store anything on null_resource

### DIFF
--- a/null/resource.go
+++ b/null/resource.go
@@ -17,6 +17,7 @@ func resource() *schema.Resource {
 		Create: resourceCreate,
 		Read:   resourceRead,
 		Delete: resourceDelete,
+		Update: resourceUpdate,
 
 		Schema: map[string]*schema.Schema{
 			"triggers": &schema.Schema{
@@ -24,16 +25,34 @@ func resource() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"values": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
+			"inputs": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
+			"outputs": &schema.Schema{
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
 		},
 	}
 }
 
 func resourceCreate(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(fmt.Sprintf("%d", rand.Int()))
+	d.Set("outputs", d.Get("inputs"))
+	d.Set("triggers", d.Get("triggers"))
 	return nil
 }
 
 func resourceRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceUpdate(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 

--- a/website/docs/resource.html.markdown
+++ b/website/docs/resource.html.markdown
@@ -58,7 +58,10 @@ The following arguments are supported:
 
 * `triggers` - (Optional) A map of arbitrary strings that, when changed, will
   force the null resource to be replaced, re-running any associated
-provisioners.
+  provisioners.
+* `values` - (Optional) A map of values that can be added to the null resource.
+* `inputs` - (Optional) A map of values that are copied to `outputs` when the
+  resource is created.
 
 ## Attributes Reference
 
@@ -67,3 +70,4 @@ The following attributes are exported:
 * `id` - An arbitrary value that changes each time the resource is replaced.
   Can be used to cause other resources to be updated or replaced in response
   to `null_resource` changes.
+* `outputs` - A copy of the `inputs` argument at creation time.


### PR DESCRIPTION
The null_resource can be great to store any value. This commit add the
bility to store arbitrary values without recreating the resources (in
the `values` section) and to store `inputs` that are stored within the
tfstate, accessible as `outputs` and updated only when the resource is
(re-)created.

This can solve use case in issue #5