### PR TITLE
Update docs link to random provider to the Registry

### DIFF
--- a/website/docs/data_source.html.markdown
+++ b/website/docs/data_source.html.markdown
@@ -60,5 +60,5 @@ The following attributes are exported:
 
 * `random` - A random value. This is primarily for testing and has little
   practical use; prefer
-  [the `random` provider](/docs/providers/random/)
+  [the `random` provider](https://registry.terraform.io/providers/hashicorp/random)
   for more practical random number use-cases.


### PR DESCRIPTION
The current relative link is formatted for provider docs on the terrform.io website. As provider docs are moving to the Registry, this link no longer works as intended because there is a different relative path structure. This PR updates a relative link to an absolute link from docs within the `null` provider to the `random` provider, which also enables viewing the link from both the Registry and terraform.io.