### PR TITLE
tree-wide: fix references to the terraform-providers organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@ Requirements
 Building The Provider
 ---------------------
 
-Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-null`
+Clone repository to: `$GOPATH/src/github.com/hashicorp/terraform-provider-null`
 
 ```sh
-$ git clone git@github.com:terraform-providers/terraform-provider-null $GOPATH/src/github.com/terraform-providers/terraform-provider-null
+$ git clone git@github.com:hashicorp/terraform-provider-null $GOPATH/src/github.com/hashicorp/terraform-provider-null
 ```
 
 Enter the provider directory and build the provider
 
 ```sh
-$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-null
+$ cd $GOPATH/src/github.com/hashicorp/terraform-provider-null
 $ make build
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-providers/terraform-provider-null
+module github.com/hashicorp/terraform-provider-null
 
 require (
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/terraform-providers/terraform-provider-null/null"
+	"github.com/hashicorp/terraform-provider-null/null"
 )
 
 func main() {

--- a/scripts/changelog-links.sh
+++ b/scripts/changelog-links.sh
@@ -24,7 +24,7 @@ else
   SED="sed -i.bak -r -e"
 fi
 
-PROVIDER_URL="https:\/\/github.com\/terraform-providers\/terraform-provider-null\/issues"
+PROVIDER_URL="https:\/\/github.com\/hashicorp\/terraform-provider-null\/issues"
 
 $SED "s/GH-([0-9]+)/\[#\1\]\($PROVIDER_URL\/\1\)/g" -e 's/\[\[#(.+)([0-9])\)]$/(\[#\1\2))/g' CHANGELOG.md
 


### PR DESCRIPTION
`terraform-provider-null` has been moved to the `hashicorp`
organization.