### PR TITLE
Delay attribute to emulate long creation

### DIFF
--- a/null/resource.go
+++ b/null/resource.go
@@ -24,10 +24,10 @@ func resource() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
-			"delay" : {
+			"delay": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default: 0,
+				Default:  0,
 			},
 		},
 	}

--- a/null/resource.go
+++ b/null/resource.go
@@ -24,12 +24,18 @@ func resource() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"delay" : {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default: 0,
+			},
 		},
 	}
 }
 
 func resourceCreate(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(fmt.Sprintf("%d", rand.Int()))
+	time.Sleep(d.Get("delay").(time.Duration) * time.Second)
 	return nil
 }
 

--- a/website/docs/resource.html.markdown
+++ b/website/docs/resource.html.markdown
@@ -32,6 +32,9 @@ resource "null_resource" "cluster" {
     cluster_instance_ids = "${join(",", aws_instance.cluster.*.id)}"
   }
 
+  # Wait for 5 seconds before running provisioners
+  delay = 5
+
   # Bootstrap script can run on any instance of the cluster
   # So we just choose the first in this case
   connection {
@@ -61,6 +64,8 @@ The following arguments are supported:
 * `triggers` - (Optional) A map of arbitrary strings that, when changed, will
   force the null resource to be replaced, re-running any associated
 provisioners.
+
+* `delay` - (Optional) Number of seconds required to create null resource.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Add a new `delay` attribute that represents number of seconds, required to "create" new resource.

The main reason behind this change is there is no cross-platform solution for "sleep".

In some cases, underlying REST APIs contain issues that cause racings between resource being created.
As a result, tf files need some sort of artificial delay before next resource can be created.

We were using `sleep 5` inside a provisioners, however this only works for teams that use Unix-based system. On Windows, local-provisioner uses cmd line and it doesn't have any `sleep` support (there is `timeout`, but it is not working due to redirect)

This lack of cross-platform unified delay is frustrating, so would be great to emulate it via null resource.