### PR TITLE
Update goreleaser to publish manifest file via hc-releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,6 +50,9 @@ publishers:
       - AWS_ACCESS_KEY_ID={{ .Env.AWS_ACCESS_KEY_ID }}
       - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
       - AWS_SESSION_TOKEN={{ .Env.AWS_SESSION_TOKEN }}
+    extra_files:
+      - glob: 'terraform-registry-manifest.json'
+        name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
     name: hc-releases
     signature: true
 release:


### PR DESCRIPTION
The recent goreleaser v1.3.0 release allows for custom publishers to declare extra_files configuration. This will allow us to upload the manifest file to releases.hashicorp.com.