### PR TITLE
.github/workflows: Add 'go generate' testing for differences

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,18 @@ jobs:
       run: |
         go build -v .
 
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.16'
+      - uses: actions/checkout@v3
+      - run: go generate ./...
+      - name: git diff
+        run: |
+          git diff --compact-summary --exit-code || \
+            (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
 
 # run acceptance tests in a matrix with Terraform core versions
   test:


### PR DESCRIPTION
Since this project is already using `terraform-plugin-docs`, there can be differences between the source schema/markdown and generated documentation. This will ensure those differences are caught during CI.

Further documentation testing is possible via `tfproviderdocs`, however this at least covers a common issue with documentation generation.