### PR TITLE
all: Update documentation and null_data_source deprecation for new terraform_data resource

### DIFF
--- a/docs/data-sources/data_source.md
+++ b/docs/data-sources/data_source.md
@@ -6,7 +6,7 @@ description: |-
   The null_data_source data source implements the standard data source lifecycle but does not
   interact with any external APIs.
   Historically, the null_data_source was typically used to construct intermediate values to re-use elsewhere in configuration. The
-  same can now be achieved using locals https://www.terraform.io/docs/language/values/locals.html.
+  same can now be achieved using locals https://developer.hashicorp.com/terraform/language/values/locals or the terraform_data resource type https://developer.hashicorp.com/terraform/language/resources/terraform-data in Terraform 1.4 and later.
 ---
 
 # null_data_source
@@ -15,7 +15,7 @@ The `null_data_source` data source implements the standard data source lifecycle
 interact with any external APIs.
 
 Historically, the `null_data_source` was typically used to construct intermediate values to re-use elsewhere in configuration. The
-same can now be achieved using [locals](https://www.terraform.io/docs/language/values/locals.html).
+same can now be achieved using [locals](https://developer.hashicorp.com/terraform/language/values/locals) or the [terraform_data resource type](https://developer.hashicorp.com/terraform/language/resources/terraform-data) in Terraform 1.4 and later.
 
 ## Example Usage
 

--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -3,13 +3,13 @@
 page_title: "null_resource Resource - terraform-provider-null"
 subcategory: ""
 description: |-
-  The null_resource resource implements the standard resource lifecycle but takes no further action.
+  The null_resource resource implements the standard resource lifecycle but takes no further action. On Terraform 1.4 and later, use the terraform_data resource type https://developer.hashicorp.com/terraform/language/resources/terraform-data instead.
   The triggers argument allows specifying an arbitrary set of values that, when changed, will cause the resource to be replaced.
 ---
 
 # null_resource
 
-The `null_resource` resource implements the standard resource lifecycle but takes no further action.
+The `null_resource` resource implements the standard resource lifecycle but takes no further action. On Terraform 1.4 and later, use the [terraform_data resource type](https://developer.hashicorp.com/terraform/language/resources/terraform-data) instead.
 
 The `triggers` argument allows specifying an arbitrary set of values that, when changed, will cause the resource to be replaced.
 

--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -27,13 +27,13 @@ func (n *nullDataSource) Metadata(ctx context.Context, req datasource.MetadataRe
 func (n *nullDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		DeprecationMessage: "The null_data_source was historically used to construct intermediate values to re-use elsewhere " +
-			"in configuration, the same can now be achieved using locals",
+			"in configuration, the same can now be achieved using locals or the terraform_data resource type in Terraform 1.4 and later.",
 		Description: `The ` + "`null_data_source`" + ` data source implements the standard data source lifecycle but does not
 interact with any external APIs.
 
 Historically, the ` + "`null_data_source`" + ` was typically used to construct intermediate values to re-use elsewhere in configuration. The
-same can now be achieved using [locals](https://www.terraform.io/docs/language/values/locals.html).
-`,
+same can now be achieved using [locals](https://developer.hashicorp.com/terraform/language/values/locals) ` +
+			`or the [terraform_data resource type](https://developer.hashicorp.com/terraform/language/resources/terraform-data) in Terraform 1.4 and later.`,
 		Attributes: map[string]schema.Attribute{
 			"inputs": schema.MapAttribute{
 				Description: "A map of arbitrary strings that is copied into the `outputs` attribute, and accessible directly for interpolation.",

--- a/internal/provider/resource.go
+++ b/internal/provider/resource.go
@@ -31,7 +31,8 @@ func (n *nullResource) Metadata(ctx context.Context, req resource.MetadataReques
 
 func (n *nullResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: `The ` + "`null_resource`" + ` resource implements the standard resource lifecycle but takes no further action.
+		Description: `The ` + "`null_resource`" + ` resource implements the standard resource lifecycle but takes no further action. ` +
+			`On Terraform 1.4 and later, use the [terraform_data resource type](https://developer.hashicorp.com/terraform/language/resources/terraform-data) instead.
 
 The ` + "`triggers`" + ` argument allows specifying an arbitrary set of values that, when changed, will cause the resource to be replaced.`,
 		Attributes: map[string]schema.Attribute{


### PR DESCRIPTION
This will ensure the next release of this provider includes additional documentation for practitioners to discover the new `terraform_data` resource available in Terraform 1.4 and later. This does not introduce any deprecation warnings with the `null_resource` resource at the current time.