### PR TITLE
all: Add copyright headers and enable compliance checks in CI

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,0 +1,35 @@
+schema_version = 1
+
+project {
+  license        = "MPL-2.0"
+  copyright_year = 2017
+
+  header_ignore = [
+    #
+    # Common hashicorp/terraform-provider-* excludes
+    #
+
+    # changie tooling configuration and CHANGELOG entries (prose)
+    ".changes/unreleased/*.yaml",
+    ".changie.yaml",
+
+    # GitHub issue template configuration
+    ".github/ISSUE_TEMPLATE/*.yml",
+
+    # GitHub Actions workflow-specific configurations
+    ".github/labeler-*.yml",
+
+    # golangci-lint tooling configuration
+    ".golangci.yml",
+
+    # GoReleaser tooling configuration
+    ".goreleaser.yml",
+
+    # Release Engineering tooling configuration
+    ".release/*.hcl",
+
+    # terraform-plugin-docs code snippets (prose)
+    "examples/**/*.sh",
+    "examples/**/*.tf",
+  ]
+}

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -1,0 +1,16 @@
+name: compliance
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  # Reference: ENGSRV-059
+  copywrite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: hashicorp/setup-copywrite@3ace06ad72e6ec679ea8572457b17dbc3960b8ce # v1.0.0
+      - run: copywrite headers --plan

--- a/internal/planmodifiers/attribute.go
+++ b/internal/planmodifiers/attribute.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package planmodifiers
 
 import (

--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package provider
 
 import (

--- a/internal/provider/data_source_test.go
+++ b/internal/provider/data_source_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package provider
 
 import (

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package provider
 
 import (

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package provider
 
 import (

--- a/internal/provider/resource.go
+++ b/internal/provider/resource.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package provider
 
 import (

--- a/internal/provider/resource_test.go
+++ b/internal/provider/resource_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package provider
 
 import (

--- a/main.go
+++ b/main.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package main
 
 import (

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 //go:build tools
 // +build tools
 


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-providers-devex-internal/issues/127

In the near future, copyright header inclusion will be enforced on this code repository. This change adds and fixes copyright headers while also introducing a GitHub Actions workflow explicitly for all pull requests on all paths to check compliance using the available `copywrite` tooling. This is to prevent gaps between the introduction of changes and the automated enforcement system catching files out of compliance.

Prior to introducing the `copywrite` configuration file, verified the workflow failed as expected when out of compliance:

```
[compliance/copywrite]   ❓  ::group::The following files are missing headers:
| 2023-03-09T17:26:16.068Z [INFO]  cli: .changie.yaml
| 2023-03-09T17:26:16.068Z [INFO]  cli: .changes/unreleased/NOTES-20230303-161407.yaml
| 2023-03-09T17:26:16.072Z [INFO]  cli: tools/tools.go
| 2023-03-09T17:26:16.074Z [INFO]  cli: .github/ISSUE_TEMPLATE/config.yml
| 2023-03-09T17:26:16.074Z [INFO]  cli: examples/data-sources/null_data_source/data-source.tf
| 2023-03-09T17:26:16.074Z [INFO]  cli: .github/labeler-issue-triage.yml
| 2023-03-09T17:26:16.074Z [INFO]  cli: .github/labeler-pull-request-triage.yml
| 2023-03-09T17:26:16.074Z [INFO]  cli: .golangci.yml
| 2023-03-09T17:26:16.074Z [INFO]  cli: .github/ISSUE_TEMPLATE/Bug_Report.yml
| 2023-03-09T17:26:16.074Z [INFO]  cli: .goreleaser.yml
| 2023-03-09T17:26:16.074Z [INFO]  cli: .github/ISSUE_TEMPLATE/Feature_Request.yml
| 2023-03-09T17:26:16.074Z [INFO]  cli: .release/release-metadata.hcl
| 2023-03-09T17:26:16.075Z [INFO]  cli: internal/provider/provider_test.go
| 2023-03-09T17:26:16.075Z [INFO]  cli: examples/resources/null_resource/resource.tf
| 2023-03-09T17:26:16.075Z [INFO]  cli: internal/provider/resource.go
| 2023-03-09T17:26:16.075Z [INFO]  cli: internal/planmodifiers/attribute.go
| 2023-03-09T17:26:16.075Z [INFO]  cli: internal/provider/data_source.go
| 2023-03-09T17:26:16.075Z [INFO]  cli: internal/provider/data_source_test.go
| 2023-03-09T17:26:16.075Z [INFO]  cli: internal/provider/provider.go
| 2023-03-09T17:26:16.075Z [INFO]  cli: main.go
| 2023-03-09T17:26:16.075Z [INFO]  cli: internal/provider/resource_test.go
| ::endgroup::
| Error: missing license header
[compliance/copywrite]   ❌  Failure - Main copywrite headers --plan
[compliance/copywrite] exitcode '1': failure
```

It will also automatically fail if the `copywrite` configuration is invalid:

```
| Error: Unable to load config: At 17:5: error parsing list, expected comma or list end, got: STRING
[compliance/copywrite]   ❌  Failure - Main copywrite headers --plan
[compliance/copywrite] exitcode '1': failure
```