### PR TITLE
fix: issue-labeler - add required input

### DIFF
--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -13,3 +13,4 @@ jobs:
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler-issue-triage.yml
+        enable-versioned-regex: 0


### PR DESCRIPTION
This PR fixes broken ga actions due to a [breaking change w/ issue-labeler v3.0](https://github.com/github/issue-labeler/releases/tag/v3.0).

> Error: Error: Input required and not supplied: enable-versioned-regex

For more details, please see:

https://github.com/hashicorp/terraform-provider-time/pull/196#pullrequestreview-1435216975