### PR TITLE
Add changelogs for `v3.2.2` release

### DIFF
--- a/.changes/unreleased/NOTES-20230303-161407.yaml
+++ b/.changes/unreleased/NOTES-20230303-161407.yaml
@@ -1,6 +1,0 @@
-kind: NOTES
-body: This Go module has been updated to Go 1.19 per the [Go support policy](https://golang.org/doc/devel/release.html#policy).
-  Any consumers building on earlier Go versions may experience errors.
-time: 2023-03-03T16:14:07.252277Z
-custom:
-  Issue: "193"

--- a/.changes/unreleased/NOTES-20231120-084245.yaml
+++ b/.changes/unreleased/NOTES-20231120-084245.yaml
@@ -1,0 +1,6 @@
+kind: NOTES
+body: This Go module has been updated to Go 1.20 per the [Go support policy](https://golang.org/doc/devel/release.html#policy).
+  Any consumers building on earlier Go versions may experience errors.
+time: 2023-11-20T08:42:45.321503-05:00
+custom:
+  Issue: "264"

--- a/.changes/unreleased/NOTES-20231120-084245.yaml
+++ b/.changes/unreleased/NOTES-20231120-084245.yaml
@@ -1,6 +1,0 @@
-kind: NOTES
-body: This Go module has been updated to Go 1.20 per the [Go support policy](https://golang.org/doc/devel/release.html#policy).
-  Any consumers building on earlier Go versions may experience errors.
-time: 2023-11-20T08:42:45.321503-05:00
-custom:
-  Issue: "264"

--- a/.changes/unreleased/NOTES-20231120-084555.yaml
+++ b/.changes/unreleased/NOTES-20231120-084555.yaml
@@ -1,0 +1,6 @@
+kind: NOTES
+body: This release introduces no functional changes. It does however include dependency
+  updates which address upstream CVEs.
+time: 2023-11-20T08:45:55.260587-05:00
+custom:
+  Issue: "242"


### PR DESCRIPTION
Added a new changelog entry for the upcoming `v3.2.2` patch release and removed the Go upgrade changelog (since this isn't an external Go module)