### PR TITLE
chore: Update README for releasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,4 +113,4 @@ changie batch 3.2.4 && changie merge
 
 ## License
 
-[Mozilla Public License v2.0](./LICENSE)
+- [Mozilla Public License v2.0](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -113,4 +113,4 @@ changie batch 3.2.4 && changie merge
 
 ## License
 
-- [Mozilla Public License v2.0](./LICENSE)
+[Mozilla Public License v2.0](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -103,10 +103,13 @@ $ act pull_request
 
 ## Releasing
 
-The release process is automated via GitHub Actions, and it's defined in the Workflow
-[release.yml](./.github/workflows/release.yml).
+The releasable builds are generated from the [build GH workflow](./.github/workflows/build.yml) and the release/promotion process
+is completed via internal HashiCorp deployment tooling. Prior to release, the changelog should be updated in `main` with
+the changie tool, example:
 
-Each release is cut by pushing a [semantically versioned](https://semver.org/) tag to the default branch.
+```sh
+changie batch 3.2.4 && changie merge
+```
 
 ## License
 


### PR DESCRIPTION
Bringing the readme up to what's in the other utility providers on CRT