### PR TITLE
build: add linux/s390x build target

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20260511-143234.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20260511-143234.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: 'Added linux/s390x build target for IBM Z platform support'
+time: 2026-05-11T14:32:34+00:00
+custom:
+    Issue: "494"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
       fail-fast: true
       matrix:
         goos: [freebsd, windows, linux, darwin]
-        goarch: ["386", "amd64", "arm", "arm64"]
+        goarch: ["386", "amd64", "arm", "arm64", "s390x"]
         exclude:
           - goos: freebsd
             goarch: arm64
@@ -133,6 +133,12 @@ jobs:
             goarch: 386
           - goos: darwin
             goarch: arm
+          - goos: freebsd
+            goarch: s390x
+          - goos: windows
+            goarch: s390x
+          - goos: darwin
+            goarch: s390x
 
     name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
     steps:

--- a/.release/terraform-provider-null-artifacts.hcl
+++ b/.release/terraform-provider-null-artifacts.hcl
@@ -10,6 +10,7 @@ artifacts {
     "terraform-provider-null_${version}_linux_amd64.zip",
     "terraform-provider-null_${version}_linux_arm.zip",
     "terraform-provider-null_${version}_linux_arm64.zip",
+    "terraform-provider-null_${version}_linux_s390x.zip",
     "terraform-provider-null_${version}_windows_386.zip",
     "terraform-provider-null_${version}_windows_amd64.zip",
   ]


### PR DESCRIPTION
## Summary

* Add `linux/s390x` build target for IBM Z platform support
* Add `s390x` to the `goarch` build matrix in `.github/workflows/build.yml` with exclusions for freebsd, windows, and darwin
* Add `linux_s390x.zip` artifact entry to the CRT release manifest